### PR TITLE
🧪 add tests for suggestBump edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/index.ts",
-    "start": "node bin/tagman.js"
+    "start": "node bin/tagman.js",
+    "test": "tsx --test src/**/*.test.ts"
   }
 }

--- a/src/core/commits.test.ts
+++ b/src/core/commits.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { suggestBump } from "./commits.js";
+
+test("suggestBump", async (t) => {
+  await t.test("should return 'patch' for empty commit list", () => {
+    assert.strictEqual(suggestBump([]), "patch");
+  });
+
+  await t.test("should return 'patch' for non-feat non-breaking commits", () => {
+    const commits = [
+      "fix: minor bug fix",
+      "docs: update readme",
+      "chore: update dependencies"
+    ];
+    assert.strictEqual(suggestBump(commits), "patch");
+  });
+
+  await t.test("should return 'minor' if at least one feat commit is present", () => {
+    const commits = [
+      "fix: minor bug fix",
+      "feat: add new feature",
+      "chore: update dependencies"
+    ];
+    assert.strictEqual(suggestBump(commits), "minor");
+  });
+
+  await t.test("should return 'major' if BREAKING CHANGE is in the message", () => {
+    const commits = [
+      "feat: add new feature\n\nBREAKING CHANGE: this is a breaking change",
+      "fix: minor bug fix"
+    ];
+    assert.strictEqual(suggestBump(commits), "major");
+  });
+
+  await t.test("should return 'major' if !: is used", () => {
+    const commits = [
+      "feat!: add new feature with breaking change",
+      "fix: minor bug fix"
+    ];
+    assert.strictEqual(suggestBump(commits), "major");
+  });
+
+  await t.test("should return 'major' even if feat commits are also present", () => {
+    const commits = [
+      "feat: add new feature",
+      "feat!: breaking feature"
+    ];
+    assert.strictEqual(suggestBump(commits), "major");
+  });
+
+  await t.test("should return 'major' if BREAKING CHANGE is in the header", () => {
+    const commits = [
+      "fix: BREAKING CHANGE: something broke"
+    ];
+    assert.strictEqual(suggestBump(commits), "major");
+  });
+});


### PR DESCRIPTION
This PR addresses a testing gap in the `suggestBump` function by adding a robust set of test cases.

🎯 **What:** Missing edge case tests for the SemVer bump suggestion logic.
📊 **Coverage:**
- Standard commit types (fix, chore, docs) -> patch
- Feature commits (feat) -> minor
- Breaking changes (via notes, header, or !: syntax) -> major
- Priority verification (highest bump takes precedence)
- Empty state (returns patch)
✨ **Result:** Improved reliability and confidence in the versioning logic. Tests are implemented using Node's built-in test runner for minimal overhead.

---
*PR created automatically by Jules for task [9589260838413183587](https://jules.google.com/task/9589260838413183587) started by @fethabo*