### PR TITLE
feat: implement GitHub device login for missing tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@clack/core": "^1.1.0",
     "@clack/prompts": "^1.1.0",
+    "@octokit/auth-oauth-device": "^8.0.3",
     "@octokit/rest": "^22.0.1",
     "commander": "^14.0.3",
     "conventional-commits-parser": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.1.0
+      '@octokit/auth-oauth-device':
+        specifier: ^8.0.3
+        version: 8.0.3
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -256,6 +259,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -270,6 +277,14 @@ packages:
 
   '@octokit/graphql@9.0.3':
     resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
     engines: {node: '>= 20'}
 
   '@octokit/openapi-types@27.0.0':
@@ -900,6 +915,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -922,6 +944,15 @@ snapshots:
       '@octokit/request': 10.0.8
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
 
   '@octokit/openapi-types@27.0.0': {}
 

--- a/src/commands/github-release.ts
+++ b/src/commands/github-release.ts
@@ -3,17 +3,27 @@ import * as p from "@clack/prompts";
 import color from "picocolors";
 import { loadConfig } from "../config.js";
 import { listAllTags, getTagAnnotation, getGitHubRemoteInfo } from "../git/index.js";
-import { createGithubRelease } from "../integrations/github.js";
+import { createGithubRelease, interactiveGithubLogin } from "../integrations/github.js";
 import { resolveGithubToken } from "../core/token.js";
 import { setLocale, t, type Locale } from "../i18n/index.js";
 
 export async function runGithubReleaseFlow(config?: Awaited<ReturnType<typeof loadConfig>>): Promise<void> {
   const cfg = config ?? await loadConfig();
 
-  const token = await resolveGithubToken(cfg.github?.token);
+  let token = await resolveGithubToken(cfg.github?.token);
   if (!token) {
     p.log.warn(t().githubRelease.noToken);
-    return;
+    const login = await p.confirm({
+      message: t().execute.githubDeviceLoginPrompt,
+      initialValue: true,
+    });
+    if (!p.isCancel(login) && login) {
+      token = await interactiveGithubLogin();
+    }
+
+    if (!token) {
+      return;
+    }
   }
 
   const ghInfo = await getGitHubRemoteInfo();

--- a/src/commands/wizard/steps/execute.ts
+++ b/src/commands/wizard/steps/execute.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../core/updater.js";
 import { createReleaseCommit, createAnnotatedTag, deleteLocalTag, resetLastCommit, pushRelease, getGitHubRemoteInfo, git } from "../../../git/index.js";
 import { resolveGithubToken } from "../../../core/token.js";
-import { createGithubRelease } from "../../../integrations/github.js";
+import { createGithubRelease, interactiveGithubLogin } from "../../../integrations/github.js";
 import { publishPackage } from "../../../integrations/npm.js";
 import { runAfterRelease, type ReleaseResult } from "../../../plugins/index.js";
 import { saveCheckpoint, clearCheckpoint, type ReleaseState } from "../../../core/checkpoint.js";
@@ -55,8 +55,8 @@ export async function executeRelease(
 
   // Resolve GitHub context once for use in changelog generation and GitHub Releases.
   const ghInfo = await getGitHubRemoteInfo();
-  const ghToken = ghInfo ? await resolveGithubToken(config.github?.token) : null;
-  const ghContext = ghInfo
+  let ghToken = ghInfo ? await resolveGithubToken(config.github?.token) : null;
+  let ghContext = ghInfo
     ? { owner: ghInfo.owner, repo: ghInfo.repo, token: ghToken }
     : undefined;
 
@@ -220,40 +220,56 @@ export async function executeRelease(
   if (config.github?.createRelease) {
     if (!ghInfo) {
       p.log.warn(t().execute.githubNoRemote);
-    } else if (!ghToken) {
-      p.log.warn(t().execute.githubNoToken);
     } else {
-      const ghSpinner = p.spinner();
-      ghSpinner.start(t().execute.githubCreating);
-      const urls: string[] = [];
-      let skippedPrerelease = 0;
-      for (const [pkgName, details] of state.entries()) {
-        if (!details.tagMessage) continue; // skip packages where user declined tag creation (#25)
-        // Skip GitHub Release for pre-release versions when config.github.prerelease is false
-        if (details.githubPrerelease && !config.github?.prerelease) {
-          skippedPrerelease++;
-          continue;
-        }
-        try {
-          const tagName = buildTagName(pkgName, details.newVersion, config);
-          const isPrerelease = details.githubPrerelease ?? config.github.prerelease ?? false;
-          const url = await createGithubRelease({
-            token: ghToken,
-            owner: ghInfo.owner,
-            repo: ghInfo.repo,
-            tagName,
-            body: details.tagMessage ?? "",
-            prerelease: isPrerelease,
+      if (!ghToken) {
+        p.log.warn(t().execute.githubNoToken);
+        if (!yes) {
+          const login = await p.confirm({
+            message: t().execute.githubDeviceLoginPrompt,
+            initialValue: true,
           });
-          urls.push(url);
-        } catch (e: any) {
-          p.log.warn(t().execute.githubFailed(pkgName, e.message));
+          if (!p.isCancel(login) && login) {
+            ghToken = await interactiveGithubLogin();
+            if (ghToken) {
+              ghContext = { owner: ghInfo.owner, repo: ghInfo.repo, token: ghToken };
+            }
+          }
         }
       }
-      ghSpinner.stop(t().execute.githubDone(urls.length));
-      for (const url of urls) p.log.info(`  ${url}`);
-      if (skippedPrerelease > 0) {
-        p.log.warn(t().execute.githubSkippedPrerelease);
+
+      if (ghToken) {
+        const ghSpinner = p.spinner();
+        ghSpinner.start(t().execute.githubCreating);
+        const urls: string[] = [];
+        let skippedPrerelease = 0;
+        for (const [pkgName, details] of state.entries()) {
+          if (!details.tagMessage) continue; // skip packages where user declined tag creation (#25)
+          // Skip GitHub Release for pre-release versions when config.github.prerelease is false
+          if (details.githubPrerelease && !config.github?.prerelease) {
+            skippedPrerelease++;
+            continue;
+          }
+          try {
+            const tagName = buildTagName(pkgName, details.newVersion, config);
+            const isPrerelease = details.githubPrerelease ?? config.github.prerelease ?? false;
+            const url = await createGithubRelease({
+              token: ghToken,
+              owner: ghInfo.owner,
+              repo: ghInfo.repo,
+              tagName,
+              body: details.tagMessage ?? "",
+              prerelease: isPrerelease,
+            });
+            urls.push(url);
+          } catch (e: any) {
+            p.log.warn(t().execute.githubFailed(pkgName, e.message));
+          }
+        }
+        ghSpinner.stop(t().execute.githubDone(urls.length));
+        for (const url of urls) p.log.info(`  ${url}`);
+        if (skippedPrerelease > 0) {
+          p.log.warn(t().execute.githubSkippedPrerelease);
+        }
       }
     }
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -188,5 +188,8 @@ export const en: Messages = {
     reorderLifting: "Reordering commits around release...",
     reorderDone: "Commits reordered successfully.",
     reorderFailed: (msg) => `Commit reorder failed: ${msg}. Reverting to original state.`,
+    githubDeviceLoginPrompt: "No GitHub token found. Do you want to do a one-time login via browser to create the release? (The token will not be saved)",
+    githubDeviceLoginInstructions: (url, code) => `Please open ${url} and enter the code: ${code}`,
+    githubDeviceLoginSuccess: "GitHub login successful.",
   },
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -188,5 +188,8 @@ export const es: Messages = {
     reorderLifting: "Reordenando commits alrededor del release...",
     reorderDone: "Commits reordenados correctamente.",
     reorderFailed: (msg) => `Falló el reordenamiento: ${msg}. Revirtiendo al estado original.`,
+    githubDeviceLoginPrompt: "No se encontró token de GitHub. ¿Querés iniciar sesión por única vez via navegador para crear el release? (El token no se guardará)",
+    githubDeviceLoginInstructions: (url, code) => `Por favor abrí ${url} e ingresá el código: ${code}`,
+    githubDeviceLoginSuccess: "Sesión de GitHub iniciada exitosamente.",
   },
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -182,5 +182,8 @@ export type Messages = {
     reorderDone: string;
     reorderFailed: (msg: string) => string;
     githubSkippedPrerelease: string;
+    githubDeviceLoginPrompt: string;
+    githubDeviceLoginInstructions: (url: string, code: string) => string;
+    githubDeviceLoginSuccess: string;
   };
 };

--- a/src/integrations/github.ts
+++ b/src/integrations/github.ts
@@ -1,4 +1,29 @@
 import { Octokit } from "@octokit/rest";
+import { createOAuthDeviceAuth } from "@octokit/auth-oauth-device";
+import * as p from "@clack/prompts";
+import color from "picocolors";
+import { t } from "../i18n/index.js";
+
+const GITHUB_CLI_CLIENT_ID = "178c6fc778ccc68e1d6a";
+
+export async function interactiveGithubLogin(): Promise<string | null> {
+  const auth = createOAuthDeviceAuth({
+    clientType: "oauth-app",
+    clientId: GITHUB_CLI_CLIENT_ID,
+    scopes: ["repo"],
+    onVerification(verification) {
+      p.log.info(t().execute.githubDeviceLoginInstructions(color.cyan(verification.verification_uri), color.bold(verification.user_code)));
+    },
+  });
+
+  try {
+    const result = await auth({ type: "oauth" });
+    p.log.success(t().execute.githubDeviceLoginSuccess);
+    return result.token;
+  } catch (error) {
+    return null;
+  }
+}
 
 export async function createGithubRelease(opts: {
   token: string;


### PR DESCRIPTION
Implements an interactive fallback using `@octokit/auth-oauth-device`
when `github_token` is not found, allowing the user to create
releases without manually exporting tokens. The token is kept
in memory and not saved to disk. Adds related i18n messages.

---
*PR created automatically by Jules for task [11822202852377426952](https://jules.google.com/task/11822202852377426952) started by @fethabo*