### PR TITLE
Fix Git History Bug and Improve Multi-Package Wizard UX

### DIFF
--- a/src/commands/wizard/steps/scan-and-select.ts
+++ b/src/commands/wizard/steps/scan-and-select.ts
@@ -152,12 +152,15 @@ export async function scanAndSelectPackages(
 
   const state = new Map<string, ReleaseState>();
   const queue = [...selectedNames];
+  const totalInQueue = queue.length;
   const processed = new Set<string>();
   let hasReorder = false;
 
   while (queue.length > 0) {
     const pkgName = queue.shift()!;
     if (processed.has(pkgName)) continue;
+    const progressCount = processed.size + 1;
+    const progressLabel = totalInQueue > 1 ? color.dim(` ${t().scan.progress(progressCount, totalInQueue)}`) : "";
 
     const pkgInfo = allCandidates.find(info => info.pkg.manifest.name === pkgName);
     if (!pkgInfo) {
@@ -198,7 +201,7 @@ export async function scanAndSelectPackages(
           if (pkgInfo.extraCommits.length > 0) {
             const extraCountInfo = color.dim(`(${t().scan.selectExtraCommitsCount(pkgInfo.extraCommits.length, pkgInfo.lastTag)})`);
             const extraHashes = await commitMultiSelect(
-              `${t().scan.selectExtraCommits(pkgName)} ${color.cyan(pkgName)} ${extraCountInfo}`,
+              `${t().scan.selectExtraCommits(pkgName)} ${color.cyan(pkgName)}${progressLabel} ${extraCountInfo}`,
               pkgInfo.extraCommits.map(c => ({
                 value: c.hash,
                 label: linkifyCommitMessage(`${c.hash.substring(0, 7)} - ${c.message}`, repoBaseUrl),
@@ -223,7 +226,7 @@ export async function scanAndSelectPackages(
 
           if (!pkgInfo.isExtraOnly) {
             const selectedCommitHashes = await commitMultiSelect(
-              `${t().scan.selectCommits(pkgName)} ${color.cyan(pkgName)} ${color.dim(`[${currentBranch}]`)}`,
+              `${t().scan.selectCommits(pkgName)} ${color.cyan(pkgName)}${progressLabel} ${color.dim(`[${currentBranch}]`)}`,
               pkgInfo.commits.map(c => ({
                 value: c.hash,
                 label: linkifyCommitMessage(`${c.hash.substring(0, 7)} - ${c.message}`, repoBaseUrl),
@@ -341,7 +344,7 @@ export async function scanAndSelectPackages(
             if (pkgInfo.extraCommits.length > 0) {
               const extraCountInfo = color.dim(`(${t().scan.selectExtraCommitsCount(pkgInfo.extraCommits.length, pkgInfo.lastTag)})`);
               const extraHashes = await commitMultiSelect(
-                `${t().scan.selectExtraCommits(pkgName)} ${color.cyan(pkgName)} ${extraCountInfo}`,
+                `${t().scan.selectExtraCommits(pkgName)} ${color.cyan(pkgName)}${progressLabel} ${extraCountInfo}`,
                 pkgInfo.extraCommits.map(c => ({
                   value: c.hash,
                   label: linkifyCommitMessage(`${c.hash.substring(0, 7)} - ${c.message}`, repoBaseUrl),
@@ -415,7 +418,7 @@ export async function scanAndSelectPackages(
           );
 
           const result = await wizardSelect(
-            `${t().scan.selectBump(pkgName, currentVersion)} ${color.cyan(pkgName)} (Current: ${currentVersion})`,
+            `${t().scan.selectBump(pkgName, currentVersion)} ${color.cyan(pkgName)}${progressLabel} (Current: ${currentVersion})`,
             mainBumpOptions,
             isGraduationMode ? "graduate" : (isCurrentPrerelease ? (isCurrentHotfix ? "hotfix" : "prerelease") : suggested),
             t().scan.goBack,
@@ -436,7 +439,7 @@ export async function scanAndSelectPackages(
             preReleaseLoop: while (!preBumpSettled) {
               // Step 3a: Pre-release base bump type
               const typeResult = await wizardSelect(
-                t().scan.selectPreReleaseType(pkgName),
+                `${t().scan.selectPreReleaseType(pkgName)}${progressLabel}`,
                 [
                   { value: "prepatch", label: t().scan.prepatch(semver.inc(currentVersion, "prepatch", "alpha")!) },
                   { value: "preminor", label: t().scan.preminor(semver.inc(currentVersion, "preminor", "alpha")!) },
@@ -471,7 +474,7 @@ export async function scanAndSelectPackages(
                   { value: "custom", label: t().scan.channelCustom },
                 );
                 const channelResult = await wizardSelect(
-                  t().scan.selectChannel,
+                  `${t().scan.selectChannel}${progressLabel}`,
                   channelOptions,
                   isDefaultBranch ? "alpha" : currentBranch,
                   t().scan.goBack,
@@ -661,7 +664,7 @@ export async function scanAndSelectPackages(
       ? `${config.annotationMessage}\n\n`
       : "";
 
-    const defaultTagMsg = `Release ${tagHeader}\n\n${annotationPrefix}` + items.join("\n");
+    const defaultTagMsg = `${tagHeader}\n\n${annotationPrefix}` + items.join("\n");
 
     state.set(pkgName, {
       pkg: pkgInfo.pkg,

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -81,14 +81,16 @@ export async function getCommitsForPath(path: string, sinceTag: string | null): 
       path,
     ]);
 
-    return log.all.map(c => ({
-      hash: c.hash,
-      date: c.date,
-      message: c.message,
-      body: c.body,
-      author_name: c.author_name,
-      author_email: c.author_email,
-    }));
+    return log.all
+      .filter(c => !c.message.startsWith("chore(release):") && !c.message.startsWith("chore(pre-release):"))
+      .map(c => ({
+        hash: c.hash,
+        date: c.date,
+        message: c.message,
+        body: c.body,
+        author_name: c.author_name,
+        author_email: c.author_email,
+      }));
   } catch (error) {
     console.error(`Error getting commits for path ${path}:`, error);
     return [];
@@ -102,14 +104,16 @@ export async function getCommitsForPath(path: string, sinceTag: string | null): 
 export async function getRepoCommitsSince(sinceTag: string | null): Promise<CommitInfo[]> {
   try {
     const log = await git.log([sinceTag ? `${sinceTag}..HEAD` : "HEAD"]);
-    return log.all.map(c => ({
-      hash: c.hash,
-      date: c.date,
-      message: c.message,
-      body: c.body,
-      author_name: c.author_name,
-      author_email: c.author_email,
-    }));
+    return log.all
+      .filter(c => !c.message.startsWith("chore(release):") && !c.message.startsWith("chore(pre-release):"))
+      .map(c => ({
+        hash: c.hash,
+        date: c.date,
+        message: c.message,
+        body: c.body,
+        author_name: c.author_name,
+        author_email: c.author_email,
+      }));
   } catch {
     return [];
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -104,6 +104,7 @@ export const en: Messages = {
     cascadeGoBack: "Go back to step 3",
     cascadeYes: "Yes",
     cascadeNo: "No",
+    progress: (current, total) => `[Package ${current} of ${total}]`,
   },
   tagMessages: {
     createTagQuestion: (pkg, version) => `Create a Git tag for ${pkg}@${version}?`,
@@ -139,7 +140,7 @@ export const en: Messages = {
     resumeQuestion: "Do you want to resume it?",
     resume: "Resume draft",
     discard: "Discard and start fresh",
-    summaryTitle: "Planned release summary",
+    summaryTitle: "Planned changes summary",
     actionQuestion: "What do you want to do?",
     proceed: "Proceed with the release",
     save: "Save as draft and exit",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -104,6 +104,7 @@ export const es: Messages = {
     cascadeGoBack: "Volver al paso 3",
     cascadeYes: "Sí",
     cascadeNo: "No",
+    progress: (current, total) => `[Paquete ${current} de ${total}]`,
   },
   tagMessages: {
     createTagQuestion: (pkg, version) => `¿Crear tag de Git para ${pkg}@${version}?`,
@@ -139,7 +140,7 @@ export const es: Messages = {
     resumeQuestion: "¿Querés retomarlo?",
     resume: "Retomar borrador",
     discard: "Descartar y empezar de nuevo",
-    summaryTitle: "Resumen del release planificado",
+    summaryTitle: "Resumen de cambios planificado",
     actionQuestion: "¿Qué querés hacer?",
     proceed: "Continuar con el release",
     save: "Guardar como borrador y salir",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -98,6 +98,7 @@ export type Messages = {
     cascadeGoBack: string;
     cascadeYes: string;
     cascadeNo: string;
+    progress: (current: number, total: number) => string;
   };
   tagMessages: {
     createTagQuestion: (pkg: string, version: string) => string;


### PR DESCRIPTION
Fixes #54 by addressing multi-package git history pollution and improving the wizard UX with progress indicators, cleaner copy, and unopinionated tag generation messages.

---
*PR created automatically by Jules for task [3502148219254101577](https://jules.google.com/task/3502148219254101577) started by @fethabo*